### PR TITLE
Add mobile-focused stress calculator and link from landing

### DIFF
--- a/apps/calculadora-esforc-senzilla.html
+++ b/apps/calculadora-esforc-senzilla.html
@@ -1,0 +1,634 @@
+<!doctype html>
+<html lang="ca">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Calculadora d'Esforç Senzilla — Vibe Coding Educatiu UI</title>
+<link rel="stylesheet" href="../assets/css/shell.css" />
+<style>
+/* ================================
+   🌈 PALETA (NO CANVIAR)
+   ================================ */
+:root{
+  --bg-top:#0b1226;              /* Fons principal: gradient vertical */
+  --bg-bottom:#0f172a;
+  --card: rgba(17,24,39,.75);    /* Targetes/cards */
+  --border: rgba(148,163,184,.15); /* Contorns i divisòries */
+  --border-strong: rgba(148,163,184,.30);
+  --text:#e5e7eb;                /* Text principal */
+  --muted:#94a3b8;               /* Text secundari/muted */
+  --accent:#38bdf8;              /* Accent primari (UI, sliders, icones) */
+  --grad-a:#38bdf8;              /* Gradient destacat en visuals */
+  --grad-b:#a78bfa;
+  --error:#ef4444;               /* Errors validació */
+  --card-radius:16px;
+  --btn-radius:12px;
+  --input-radius:10px;
+  --shadow:0 10px 30px rgba(0,0,0,.35), inset 0 1px 0 rgba(255,255,255,.03);
+  --transition:300ms cubic-bezier(.22,1,.36,1); /* easeOutCubic */
+}
+
+/* ================================
+   🅰️ TIPOGRAFIA (NO CANVIAR)
+   ================================ */
+html,body{
+  height:100%;
+  background: linear-gradient(to bottom, var(--bg-top), var(--bg-bottom));
+  color: var(--text);
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+}
+body{
+  margin:0;
+  min-height:100vh;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+}
+code, .mono{
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New";
+}
+
+/* ================================
+   📐 LAYOUT
+   ================================ */
+nav.top-nav{margin-bottom:12px;}
+.container{
+  max-width:960px;
+  width:100%;
+  margin:0 auto;
+  padding:32px 24px 24px;
+}
+.card > .back-link{margin-bottom:18px;}
+.card{
+  background: var(--card);
+  border:1px solid var(--border);
+  border-radius: var(--card-radius);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  padding:24px;
+}
+h1{
+  font-weight:700;
+  margin:0 0 10px 0;
+  font-size: clamp(22px, 2.8vw, 32px); /* (NO CANVIAR) */
+  letter-spacing:.2px;
+}
+.subtle{
+  color: var(--muted);
+  font-size:.95rem;
+}
+
+/* ================================
+   👆 INPUTS I CONTROL SEGMENTAT
+   ================================ */
+.row{
+  display:grid;
+  gap:16px;
+}
+@media (min-width:760px){
+  .row.cols-2{ grid-template-columns: 1fr 1fr; }
+  .row.cols-3{ grid-template-columns: 1fr 1fr 1fr; }
+}
+
+.field{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+label{
+  color: var(--muted);
+  font-size:.92rem;
+}
+select, input[type="number"], .pill{
+  background:#0f172a;
+  color:var(--text);
+  border:1px solid var(--border-strong);
+  border-radius:var(--input-radius);
+  padding:10px 12px;
+  transition:border-color var(--transition), transform var(--transition), box-shadow var(--transition);
+  outline:none;
+}
+select:focus, input[type="number"]:focus{
+  border-color:var(--accent);
+  box-shadow:0 0 0 3px rgba(56,189,248,.15);
+  transform: translateY(-1px);
+}
+input[type="range"]{
+  width:100%;
+  accent-color: var(--accent); /* (NO CANVIAR) */
+}
+
+/* Segmented control píndola */
+.segmented{
+  display:inline-grid;
+  grid-auto-flow:column;
+  gap:8px;
+  background: #0f172a;
+  padding:6px;
+  border-radius:999px;
+  border:1px solid var(--border-strong);
+}
+.segmented input{ display:none; }
+.segmented label{
+  cursor:pointer;
+  padding:8px 14px;
+  border-radius:999px;
+  color:var(--muted);
+  user-select:none;
+  transition: background var(--transition), color var(--transition), transform var(--transition);
+}
+.segmented input:checked + label{
+  background: var(--accent); /* opció activa */
+  color:#0b1226;             /* text fosc en actiu */
+  font-weight:700;
+  transform: translateY(-1px);
+}
+
+/* ================================
+   🧮 STATS GRID
+   ================================ */
+.stats{
+  display:grid;
+  gap:12px;
+}
+@media (min-width:760px){
+  .stats{ grid-template-columns: repeat(4, 1fr); }
+}
+.stat{
+  background:#0f172a;
+  border:1px solid var(--border);
+  border-radius:12px;
+  padding:12px;
+}
+.k{ font-size:12px; color:var(--muted); }
+.v{ font-size:16px; font-weight:700; }
+.v.mono{ letter-spacing:.3px; }
+
+/* ================================
+   🔘 BOTONS
+   ================================ */
+.btn{
+  background: var(--accent);
+  color:#0b1226;
+  border:none;
+  font-weight:700;
+  border-radius: var(--btn-radius);
+  padding:12px 16px;
+  cursor:pointer;
+  transition: transform var(--transition), box-shadow var(--transition), opacity var(--transition);
+}
+.btn:disabled{ opacity:.5; cursor:not-allowed; }
+.btn:hover{ transform: translateY(-1px); box-shadow:0 10px 20px rgba(56,189,248,.2); }
+
+/* ================================
+   ⚠️ VALIDACIÓ
+   ================================ */
+.error{
+  color:var(--error);
+  font-size:.92rem;
+  min-height:1.1em;
+}
+
+/* ================================
+   📊 FORMULES & VISUALS
+   ================================ */
+.formula{
+  background: #0f172a;
+  border:1px dashed var(--border-strong);
+  border-radius:12px;
+  padding:12px;
+  font-size:.98rem;
+}
+.formula .big{
+  display:block;
+  font-size:1.05rem;
+  margin-bottom:6px;
+}
+.formula .sub{
+  color:var(--muted);
+  font-size:.9rem;
+}
+
+/* SVG responsiu de la biga */
+.visual{
+  width:100%;
+  height:220px;
+  border:1px solid var(--border);
+  border-radius:12px;
+  background: linear-gradient(180deg, rgba(56,189,248,.05), rgba(167,139,250,.04));
+  overflow:hidden;
+  position:relative;
+}
+.legend{
+  position:absolute; right:10px; top:10px; display:flex; gap:12px; align-items:center;
+  font-size:.85rem; color:var(--muted);
+}
+.legend span{ display:flex; gap:6px; align-items:center; }
+.bullet{ width:16px; height:6px; border-radius:999px; }
+.bullet.grad{ background: linear-gradient(90deg, var(--grad-a), var(--grad-b)); }
+.bullet.ref{ background: repeating-linear-gradient(90deg, rgba(229,231,235,.7) 0 6px, rgba(229,231,235,0) 6px 12px); }
+
+/* Peu de pàgina (NO MODIFICAR TEXT) */
+footer{
+  margin-top:18px;
+  text-align:center;
+  color:var(--muted);
+  font-size:.9rem;
+}
+.small{ font-size:.85rem; color:var(--muted); }
+</style>
+</head>
+<body>
+  <nav class="top-nav" aria-label="Navegació principal">
+    <a class="logo" href="../index.html"><span>VC</span>Aula d'Estructures</a>
+    <a class="back-link" href="../index.html" aria-label="Torna a la portada de l'Aula d'Estructures">← Torna a l'inici</a>
+  </nav>
+  <main class="container" role="main">
+    <section class="card" aria-labelledby="titol">
+      <h1 id="titol">Calculadora d'esforç (σ) per a tracció/compressió — nivell bàsic</h1>
+      <p class="subtle">App pensada per a l'alumnat amb més dificultats: opcions acotades, fórmules visibles i passos guiats. Totes les xifres es mostren amb format <span class="mono">ca-ES</span>.</p>
+
+      <!-- ===============================
+           PAS 1 · TIPUS D'ESFORÇ
+           =============================== -->
+      <div class="row" style="margin-top:16px;">
+        <div class="field" role="group" aria-label="Tria el tipus d'esforç">
+          <label>1) Tria el tipus d'esforç</label>
+          <div class="segmented" aria-live="polite">
+            <input type="radio" name="mode" id="modeT" value="traccio" checked>
+            <label for="modeT">Tracció</label>
+            <input type="radio" name="mode" id="modeC" value="compressio">
+            <label for="modeC">Compressió</label>
+          </div>
+          <span class="small">Recorda: tracció estira la peça; compressió l'escurça.</span>
+        </div>
+      </div>
+
+      <!-- ===============================
+           PAS 2 · MATERIAL I DIMENSIONS
+           =============================== -->
+      <div class="row cols-3" style="margin-top:18px;">
+        <div class="field">
+          <label for="material">2) Material (Mòdul d'Elasticitat E)</label>
+          <select id="material" aria-label="Material">
+            <option value="200000">Acer (E ≈ 200.000 MPa)</option>
+            <option value="70000">Alumini (E ≈ 70.000 MPa)</option>
+            <option value="11000">Fusta (E ≈ 11.000 MPa)</option>
+            <option value="3500">Plàstic tècnic (E ≈ 3.500 MPa)</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="seccio">3) Secció (àrea A)</label>
+          <select id="seccio" aria-label="Secció">
+            <option value="100">Barra petita — A = 100 mm²</option>
+            <option value="250" selected>Barra mitjana — A = 250 mm²</option>
+            <option value="500">Barra gran — A = 500 mm²</option>
+            <option value="1000">Placa — A = 1.000 mm²</option>
+          </select>
+          <span class="small">Consell: secció més gran → menys tensió per la mateixa força.</span>
+        </div>
+        <div class="field">
+          <label for="longitud">4) Longitud inicial (L)</label>
+          <select id="longitud" aria-label="Longitud">
+            <option value="200">L = 200 mm</option>
+            <option value="300" selected>L = 300 mm</option>
+            <option value="400">L = 400 mm</option>
+            <option value="600">L = 600 mm</option>
+          </select>
+        </div>
+      </div>
+
+      <!-- ===============================
+           PAS 3 · FORÇA APLICADA
+           =============================== -->
+      <div class="row cols-2" style="margin-top:18px;">
+        <div class="field">
+          <label for="forcaNum">5) Força aplicada (F) en N</label>
+          <input id="forcaNum" type="number" inputmode="decimal" step="10" min="0" max="50000" value="1000" aria-describedby="forcaHelp" aria-label="Força en Newtons (nombre)">
+          <span id="forcaHelp" class="small">Mou també el control lliscant. Rang: 0 → 50.000 N</span>
+          <div style="margin-top:6px">
+            <input id="forcaRange" type="range" min="0" max="50000" step="10" value="1000" aria-label="Força en Newtons (lliscant)">
+          </div>
+          <div id="errorForca" class="error" aria-live="polite"></div>
+        </div>
+        <div class="field">
+          <label for="sigmaAdm">6) Límite admissible (σ<sub>adm</sub>)</label>
+          <select id="sigmaAdm" aria-label="Límit admissible de tensió">
+            <option value="80">80 MPa (molt conservador)</option>
+            <option value="120" selected>120 MPa (conservador)</option>
+            <option value="160">160 MPa (estàndard)</option>
+            <option value="220">220 MPa (elevat)</option>
+          </select>
+          <span class="small">Es farà una comparativa de seguretat: σ ≤ σ<sub>adm</sub>?</span>
+        </div>
+      </div>
+
+      <!-- ===============================
+           FORMULES VISIBLES (amb substitució)
+           =============================== -->
+      <div class="row" style="margin-top:8px;">
+        <div class="formula" aria-live="polite">
+          <span class="big">Fórmules clau</span>
+          <div>1) <span class="mono">σ = F / A</span> <span class="sub">→ Tensió (MPa) si F en N i A en mm² (recorda: 1 N/mm² = 1 MPa)</span></div>
+          <div>2) <span class="mono">ε = ΔL / L</span> <span class="sub">→ Deformació (sense unitat)</span></div>
+          <div>3) <span class="mono">σ = E · ε</span> <span class="sub">→ Llei de Hooke (règim elàstic)</span></div>
+          <div>4) <span class="mono">ΔL = F · L / (A · E)</span> <span class="sub">→ Allargament/escurçament teòric</span></div>
+          <hr style="border:none;border-top:1px solid var(--border); margin:10px 0">
+          <div id="substitucions" class="mono" aria-label="Substitució numèrica pas a pas"></div>
+        </div>
+      </div>
+
+      <!-- ===============================
+           VISUAL INTERACTIU (SVG)
+           =============================== -->
+      <div class="row" style="margin-top:14px;">
+        <div class="visual" aria-label="Visualització de la biga">
+          <!-- llegenda -->
+          <div class="legend">
+            <span><i class="bullet ref"></i> referència</span>
+            <span><i class="bullet grad"></i> peça deformada</span>
+          </div>
+          <!-- SVG -->
+          <svg id="svg" viewBox="0 0 900 220" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Biga amb comparativa de deformació">
+            <!-- Límit del suport esquerre (fix) -->
+            <rect x="70" y="40" width="10" height="140" fill="rgba(229,231,235,.35)"/>
+            <!-- Marca dreta referència (segueix la peça sense deformar) -->
+            <rect id="rightRef" x="830" y="40" width="10" height="140" fill="rgba(229,231,235,.35)"/>
+            <!-- Biga referència (discontínua) -->
+            <line x1="80" y1="110" x2="830" y2="110"
+                  stroke="rgba(229,231,235,.7)" stroke-width="10"
+                  stroke-dasharray="16 10" />
+            <!-- Biga deformada (gradient) -->
+            <defs>
+              <linearGradient id="barGrad" x1="0%" x2="100%">
+                <stop offset="0%" stop-color="var(--grad-a)"/>
+                <stop offset="100%" stop-color="var(--grad-b)"/>
+              </linearGradient>
+            </defs>
+            <line id="bar" x1="80" y1="110" x2="830" y2="110"
+                  stroke="url(#barGrad)" stroke-width="14" stroke-linecap="round"/>
+            <!-- Fletxes força -->
+            <g id="arrows"></g>
+          </svg>
+        </div>
+      </div>
+
+      <!-- ===============================
+           RESULTATS (STATS GRID)
+           =============================== -->
+      <div class="row" style="margin-top:14px;">
+        <div class="stats" aria-live="polite">
+          <div class="stat">
+            <div class="k">Tensió σ (MPa)</div>
+            <div id="outSigma" class="v mono">0</div>
+          </div>
+          <div class="stat">
+            <div class="k">Deformació ε (—)</div>
+            <div id="outEps" class="v mono">0</div>
+          </div>
+          <div class="stat">
+            <div class="k">ΔL (mm)</div>
+            <div id="outDeltaL" class="v mono">0</div>
+          </div>
+          <div class="stat">
+            <div class="k">Seguretat (σ ≤ σ<sub>adm</sub>)</div>
+            <div id="outSafe" class="v mono">—</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ===============================
+           ACCIONS
+           =============================== -->
+      <div class="row cols-2" style="margin-top:16px; align-items:end;">
+        <div class="field">
+          <label for="pasBuit">Prova tu: completa (σ = F / A) amb els teus valors</label>
+          <input id="pasBuit" class="mono" type="text" placeholder="Ex.: σ = 1000 / 250 = 4 MPa" aria-label="Buit per omplir la substitució manual">
+          <span class="small">Escriu la teua substitució per comprovar-la amb el resultat.</span>
+        </div>
+        <div style="display:flex; gap:10px; justify-content:flex-end;">
+          <button id="btnReset" class="btn" aria-label="Reinicia valors">Reset</button>
+          <button id="btnCalc" class="btn" aria-label="Recalcula">Recalcula</button>
+        </div>
+      </div>
+
+      <footer>Fet per Juan Arambul com a complement al tema d'Estructures i Esforços</footer>
+    </section>
+  </main>
+
+<script>
+/* ======================================================================
+   🧠 JS — ESTRUCTURA
+   - Sync inputs (number <-> range)
+   - Validació i càlculs
+   - Visual SVG amb lerp/clamp i micro-animacions (300 ms easeOutCubic)
+   - Internac.: toLocaleString('ca-ES')
+   ====================================================================== */
+
+/* -----------------------------
+   Utilitats numèriques
+------------------------------*/
+const clamp = (v, a, b) => Math.min(Math.max(v, a), b);
+const easeOutCubic = t => 1 - Math.pow(1 - t, 3);
+const fmt = (x, d=3) => {
+  if (!isFinite(x)) return '—';
+  return Number(x).toLocaleString('ca-ES', {maximumFractionDigits:d});
+};
+
+/* -----------------------------
+   Elements del DOM
+------------------------------*/
+const modeT = document.getElementById('modeT');
+const modeC = document.getElementById('modeC');
+const material = document.getElementById('material');
+const seccio = document.getElementById('seccio');
+const longitud = document.getElementById('longitud');
+const forcaNum = document.getElementById('forcaNum');
+const forcaRange = document.getElementById('forcaRange');
+const sigmaAdm = document.getElementById('sigmaAdm');
+const errorForca = document.getElementById('errorForca');
+
+const outSigma = document.getElementById('outSigma');
+const outEps = document.getElementById('outEps');
+const outDeltaL = document.getElementById('outDeltaL');
+const outSafe = document.getElementById('outSafe');
+const substitucions = document.getElementById('substitucions');
+
+const btnCalc = document.getElementById('btnCalc');
+const btnReset = document.getElementById('btnReset');
+
+const svg = document.getElementById('svg');
+const bar = document.getElementById('bar');
+const rightRef = document.getElementById('rightRef');
+const arrows = document.getElementById('arrows');
+
+/* -----------------------------
+   Sync inputs (number <-> range)
+------------------------------*/
+function syncFromNumber(){
+  const v = Number(forcaNum.value);
+  if (Number.isNaN(v)) return;
+  forcaRange.value = clamp(v, Number(forcaRange.min), Number(forcaRange.max));
+  calc();
+}
+function syncFromRange(){
+  forcaNum.value = forcaRange.value;
+  calc();
+}
+forcaNum.addEventListener('input', syncFromNumber);
+forcaRange.addEventListener('input', syncFromRange);
+
+/* -----------------------------
+   Càlculs principals
+   σ = F/A  (N/mm² = MPa)
+   ΔL = F·L / (A·E)
+   ε = ΔL/L
+------------------------------*/
+function calc(){
+  errorForca.textContent = '';
+  const F = Number(forcaRange.value);           // N
+  const A = Number(seccio.value);               // mm²
+  const L = Number(longitud.value);             // mm
+  const E = Number(material.value);             // MPa ( = N/mm² )
+  const sigAdm = Number(sigmaAdm.value);        // MPa
+
+  // Validació bàsica
+  if (F < 0 || F > 50000){
+    errorForca.textContent = 'La força ha d’estar entre 0 i 50.000 N.';
+    return;
+  }
+
+  // Tensió en MPa (N/mm²)
+  const sigma = F / A;
+
+  // ΔL en mm: ΔL = (F·L)/(A·E)
+  const deltaL = (F * L) / (A * E);
+
+  // ε sense unitat
+  const eps = deltaL / L;
+
+  // Substitucions (pas a pas)
+  substitucions.innerHTML =
+    `σ = F / A = ${fmt(F,3)} / ${fmt(A,3)} = <b>${fmt(sigma,3)} MPa</b><br>` +
+    `ΔL = F·L / (A·E) = (${fmt(F,3)}·${fmt(L,3)}) / (${fmt(A,3)}·${fmt(E,0)}) = <b>${fmt(deltaL,4)} mm</b><br>` +
+    `ε = ΔL / L = ${fmt(deltaL,4)} / ${fmt(L,3)} = <b>${fmt(eps,6)}</b>`;
+
+  // Sortides
+  outSigma.textContent = fmt(sigma,3);
+  outDeltaL.textContent = fmt(deltaL,4);
+  outEps.textContent = fmt(eps,6);
+  outSafe.textContent = (sigma <= sigAdm) ? '✅ Segur' : '⚠️ Supera límit';
+  outSafe.style.color = (sigma <= sigAdm) ? '#22c55e' : '#ef4444';
+
+  // Actualitza visual
+  updateVisual(deltaL);
+}
+
+/* -----------------------------
+   Visual SVG amb micro-animació
+   - Barres límit: esquerra fixa, dreta acompanya la biga deformada.
+   - Tracció: la punta dreta es desplaça a la dreta; Compressió: a l'esquerra.
+------------------------------*/
+let anim = { t:0, fromX2:830, toX2:830, start:0 };
+
+function updateVisual(deltaL){
+  const baseX1 = 80;      // inici biga
+  const baseX2 = 830;     // final biga sense deformar
+  const mode = modeT.checked ? 'traccio' : 'compressio';
+
+  // escala visual: 1 mm de ΔL = 0.7 px (limitat)
+  const pxPerMm = 0.7;
+  let dpx = clamp(deltaL * pxPerMm, -90, 90); // límit per no eixir del canvas
+
+  if (mode === 'compressio') dpx *= -1;
+
+  // acomodar objectiu d'animació
+  anim.fromX2 = Number(bar.getAttribute('x2'));
+  if (!anim.fromX2) anim.fromX2 = baseX2;
+  anim.toX2 = baseX2 + dpx;
+  anim.start = performance.now();
+  anim.t = 0;
+
+  // mou també la barra de referència dreta per "acompanyar" la peça
+  rightRef.setAttribute('x', baseX2 - 0); // referència resta on està (estàtica de fons)
+
+  // Fletxes de força
+  drawArrows(mode, baseX1, baseX2, dpx);
+
+  // arranca anim loop
+  requestAnimationFrame(step);
+}
+
+function step(ts){
+  const dur = 300; // 300 ms
+  const t = clamp((ts - anim.start)/dur, 0, 1);
+  const k = easeOutCubic(t);
+  const x = anim.fromX2 + (anim.toX2 - anim.fromX2)*k;
+  bar.setAttribute('x1', 80);
+  bar.setAttribute('x2', x);
+  if (t < 1) requestAnimationFrame(step);
+}
+
+/* Dibuixa fletxes de força a extrems segons mode */
+function drawArrows(mode, x1, x2, dpx){
+  const y = 110;
+  const len = 34;
+  const thick = 4;
+  arrows.innerHTML = '';
+  const g = document.createElementNS('http://www.w3.org/2000/svg','g');
+  g.setAttribute('stroke', 'var(--accent)');
+  g.setAttribute('stroke-width', thick);
+  g.setAttribute('stroke-linecap', 'round');
+
+  // Tracció: fletxes cap enfora
+  // Compressió: fletxes cap endins
+  if (mode === 'traccio'){
+    // esquerra cap a l'esquerra
+    g.appendChild(line(x1, y, x1 - len, y));
+    // dreta cap a la dreta (punta segons deformació)
+    g.appendChild(line(x2 + dpx, y, x2 + dpx + len, y));
+  }else{
+    // esquerra cap a la dreta
+    g.appendChild(line(x1 - len, y, x1, y));
+    // dreta cap a l'esquerra
+    g.appendChild(line(x2 + dpx + len, y, x2 + dpx, y));
+  }
+  arrows.appendChild(g);
+
+  function line(x1,y1,x2,y2){
+    const L = document.createElementNS('http://www.w3.org/2000/svg','line');
+    L.setAttribute('x1', x1); L.setAttribute('y1', y1);
+    L.setAttribute('x2', x2); L.setAttribute('y2', y2);
+    return L;
+  }
+}
+
+/* -----------------------------
+   Botons
+------------------------------*/
+btnCalc.addEventListener('click', calc);
+btnReset.addEventListener('click', ()=>{
+  modeT.checked = true;
+  material.value = "200000";
+  seccio.value = "250";
+  longitud.value = "300";
+  sigmaAdm.value = "120";
+  forcaRange.value = 1000;
+  forcaNum.value = 1000;
+  document.getElementById('pasBuit').value = '';
+  calc();
+});
+
+/* -----------------------------
+   Accessibilitat: recalcular en canvis
+------------------------------*/
+[modeT, modeC, material, seccio, longitud, sigmaAdm].forEach(el=>{
+  el.addEventListener('change', calc);
+});
+
+/* Inici */
+calc();
+</script>
+</body>
+</html>

--- a/apps/calculadora-traccio.html
+++ b/apps/calculadora-traccio.html
@@ -1,0 +1,740 @@
+<!DOCTYPE html>
+<html lang="ca">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Calculadora d'Esforç de Tracció / Compressió · Vibe Coding Educatiu UI</title>
+<link rel="stylesheet" href="../assets/css/shell.css" />
+<style>
+  /* =========================
+     PALETA (NO CANVIAR)
+     ========================= */
+  :root{
+    --bg-top:#0b1226;           /* gradient fons */
+    --bg-bottom:#0f172a;
+    --card:rgba(17,24,39,.75);  /* targeta */
+    --border:rgba(148,163,184,.15);
+    --border-strong:rgba(148,163,184,.30);
+    --text:#e5e7eb;
+    --muted:#94a3b8;
+    --accent:#38bdf8;           /* primari / sliders / icones */
+    --accent-2:#a78bfa;         /* gradient destacat */
+    --danger:#ef4444;           /* errors */
+    --shadow:0 20px 50px rgba(0,0,0,.45);
+    --radius-card:16px;
+    --radius:12px;
+    --radius-input:10px;
+    --dur:300ms; /* micro-animacions */
+    --ease:cubic-bezier(.22,1,.36,1); /* easeOutCubic */
+  }
+
+  /* =========================
+     RESET BÀSIC + TIPOGRAFIA
+     ========================= */
+  *{box-sizing:border-box}
+  html,body{height:100%}
+  body{
+    margin:0;
+    font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+    color:var(--text);
+    background:linear-gradient(to bottom,var(--bg-top),var(--bg-bottom));
+    min-height:100vh;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+  }
+  .wrap{
+    width:100%;
+    max-width:960px;            /* layout màx. 960px */
+    padding:24px;               /* padding base */
+    padding-top:40px;
+  }
+  .wrap > .back-link{margin-bottom:18px;}
+
+  /* =========================
+     CARD PRINCIPAL
+     ========================= */
+  .card{
+    background:var(--card);
+    border:1px solid var(--border);
+    border-radius:var(--radius-card);
+    box-shadow:var(--shadow);
+    backdrop-filter:blur(6px);
+    padding:24px;
+    transition:border-color var(--dur) var(--ease), transform var(--dur) var(--ease);
+  }
+  .card:focus-within{ border-color:var(--border-strong); transform:translateY(-1px) }
+
+  h1{
+    margin:0 0 8px;
+    font-size:clamp(22px,2.8vw,32px); /* Títol */
+    font-weight:800;
+    letter-spacing:.2px;
+  }
+  .sub{color:var(--muted); margin-bottom:18px}
+
+  /* =========================
+     LAYOUT FORM / CONTROLS
+     ========================= */
+  .grid{
+    display:grid;
+    gap:16px;
+  }
+  @media(min-width:720px){
+    .grid.cols-2{ grid-template-columns:1fr 1fr }
+    .grid.cols-3{ grid-template-columns:repeat(3,1fr) }
+  }
+
+  label{ font-size:13px; color:var(--muted); display:block; margin-bottom:8px }
+
+  .row{
+    background:rgba(15,23,42,.35);
+    border:1px solid var(--border-strong);
+    border-radius:12px;
+    padding:14px;
+  }
+
+  /* =========================
+     SEGMENTED CONTROL (píndola)
+     ========================= */
+  .seg{
+    display:inline-flex;
+    gap:6px;
+    padding:6px;
+    background:rgba(148,163,184,.08);
+    border:1px solid var(--border);
+    border-radius:999px;
+  }
+  .seg input{ position:absolute; opacity:0; pointer-events:none }
+  .seg label{
+    position:relative;
+    z-index:1;
+    cursor:pointer;
+    user-select:none;
+    padding:8px 12px;
+    border-radius:999px;
+    font-weight:600;
+    color:var(--text);
+    transition:transform var(--dur) var(--ease), color var(--dur) var(--ease);
+  }
+  .seg label:hover{ transform:translateY(-1px) }
+  .seg .pill{
+    position:absolute; inset:auto;
+    height:32px;
+    border-radius:999px;
+    background:var(--accent);
+    transition: left var(--dur) var(--ease), width var(--dur) var(--ease);
+    z-index:0;
+  }
+  .segwrap{ position:relative; display:inline-block }
+
+  /* =========================
+     INPUTS I BOTONS
+     ========================= */
+  .control{
+    display:flex;
+    align-items:center;
+    gap:10px;
+  }
+  input[type="number"], input[type="text"]{
+    width:100%;
+    background:rgba(2,6,23,.55);
+    border:1px solid var(--border-strong);
+    color:var(--text);
+    border-radius:var(--radius-input);
+    padding:10px 12px;
+    outline:none;
+    transition:border-color var(--dur) var(--ease), box-shadow var(--dur) var(--ease), transform var(--dur) var(--ease);
+    font-variant-numeric: tabular-nums;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New";
+  }
+  input[type="number"]:focus, input[type="text"]:focus{
+    border-color:var(--accent);
+    box-shadow:0 0 0 3px rgba(56,189,248,.15);
+    transform:translateY(-1px);
+  }
+
+  input[type="range"]{
+    width:100%;
+    accent-color:var(--accent); /* accent primari */
+  }
+
+  .btns{ display:flex; gap:12px; flex-wrap:wrap }
+  button{
+    border:0;
+    padding:12px 16px;
+    border-radius:var(--radius);
+    background:var(--accent);
+    color:#0b1226;
+    font-weight:700;
+    cursor:pointer;
+    transition:transform var(--dur) var(--ease), opacity var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
+    box-shadow:0 10px 30px rgba(56,189,248,.25);
+  }
+  button:hover{ transform:translateY(-1px) }
+  button:disabled{ opacity:.5; cursor:not-allowed; box-shadow:none }
+
+  /* =========================
+     STATS (k-v)
+     ========================= */
+  .stats{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(180px,1fr));
+    gap:12px;
+    margin-top:8px;
+  }
+  .stat{
+    background:rgba(2,6,23,.45);
+    border:1px solid var(--border);
+    border-radius:12px;
+    padding:12px;
+  }
+  .k{ font-size:12px; color:var(--muted); margin-bottom:6px }
+  .v{
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New";
+    font-size:16px;
+  }
+
+  /* =========================
+     MISSATGES / VALIDACIÓ
+     ========================= */
+  .error{
+    color:var(--danger);
+    font-size:13px;
+    margin-top:6px;
+  }
+
+  /* =========================
+     VISUAL SVG (comparativa)
+     ========================= */
+  .viz{
+    width:100%;
+    height:140px;
+    border:1px solid var(--border);
+    border-radius:12px;
+    background:linear-gradient(90deg, rgba(56,189,248,.08), rgba(167,139,250,.08));
+    position:relative;
+    overflow:hidden;
+  }
+  .bar{
+    position:absolute; left:0; top:0; bottom:0;
+    background:linear-gradient(90deg,var(--accent),var(--accent-2));
+    width:0%;
+    transition:width var(--dur) var(--ease);
+  }
+  .ref{
+    position:absolute; top:0; bottom:0;
+    width:2px;
+    background: repeating-linear-gradient(
+      to bottom,
+      rgba(148,163,184,.6) 0,
+      rgba(148,163,184,.6) 6px,
+      rgba(148,163,184,0) 6px,
+      rgba(148,163,184,0) 12px
+    ); /* línia discontínua de referència */
+  }
+  .viz-label{
+    position:absolute; bottom:8px; left:12px; right:12px;
+    display:flex; justify-content:space-between; font-size:12px; color:var(--muted)
+  }
+  .chip{
+    display:inline-flex; align-items:center; gap:6px;
+    padding:6px 10px; border-radius:999px; font-weight:700; font-size:12px;
+    background:rgba(2,6,23,.6); border:1px solid var(--border);
+  }
+
+  /* =========================
+     PEU DE PÀGINA (no modificar)
+     ========================= */
+  footer{
+    margin-top:18px;
+    color:var(--muted);
+    font-size:12px;
+    text-align:center;
+  }
+</style>
+</head>
+<body>
+  <nav class="top-nav" aria-label="Navegació principal">
+    <a class="logo" href="../index.html"><span>VC</span>Aula d'Estructures</a>
+    <a class="back-link" href="../index.html" aria-label="Torna a la portada de l'Aula d'Estructures">← Torna a l'inici</a>
+  </nav>
+  <main class="wrap">
+    <section class="card" aria-labelledby="ttl">
+      <h1 id="ttl">Calculadora d'Esforç de Tracció / Compressió</h1>
+      <p class="sub">Tracció / compressió, allargament i conversions d’unitats. Introdueix les dades, prem <strong>Calcular</strong> i consulta si el material <em>suporta</em> (σ &lt; E), està <em>en perill</em> (σ = E) o <em>es trenca</em> (σ &gt; E).</p>
+
+      <!-- FORMULES: blocs informatius -->
+      <div class="row" aria-live="polite">
+        <div class="grid cols-3">
+          <div>
+            <label>Esforç (tensió)</label>
+            <div class="chip" aria-label="Fórmula d'esforç">σ = F / A · [Pa]</div>
+            <div style="margin-top:6px; color:var(--muted); font-size:12px">F en newtons (N), A en m². 1 MPa = 10<sup>6</sup> Pa; 1 GPa = 10<sup>9</sup> Pa.</div>
+          </div>
+          <div>
+            <label>Allargament (deformació)</label>
+            <div class="chip" aria-label="Fórmula d'allargament">ε = ΔL / L₀ · [—]</div>
+            <div style="margin-top:6px; color:var(--muted); font-size:12px">Sense unitats. Per a % multiplica per 100.</div>
+          </div>
+          <div>
+            <label>Àrees</label>
+            <div class="chip" aria-label="Àrea cercle">A<sub>cercle</sub> = π·r²</div>
+            <div class="chip" aria-label="Àrea rectangle" style="margin-left:6px">A<sub>rectangle</sub> = ample·alt</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- SELECCIÓ D’ÀREA -->
+      <div class="row">
+        <label>Com vols introduir l’àrea?</label>
+        <div class="segwrap" role="tablist" aria-label="Mode d'entrada de l'àrea">
+          <div class="seg" id="segArea">
+            <div class="pill" aria-hidden="true"></div>
+            <input type="radio" name="areaMode" id="md-directa" value="directa" checked />
+            <label role="tab" for="md-directa" data-index="0">Àrea directa</label>
+            <input type="radio" name="areaMode" id="md-rectangle" value="rectangle" />
+            <label role="tab" for="md-rectangle" data-index="1">Rectangle</label>
+            <input type="radio" name="areaMode" id="md-cercle" value="cercle" />
+            <label role="tab" for="md-cercle" data-index="2">Cercle</label>
+          </div>
+        </div>
+
+        <div class="grid cols-3" style="margin-top:12px">
+          <!-- Àrea directa -->
+          <div id="area-directa">
+            <label for="area">Àrea A [m²]</label>
+            <input id="area" type="number" step="any" inputmode="decimal" placeholder="p. ex. 0.0005" aria-label="Àrea directa en metres quadrats">
+          </div>
+          <!-- Rectangle -->
+          <div id="area-rectangle" hidden>
+            <label for="ample">Ample [m]</label>
+            <input id="ample" type="number" step="any" inputmode="decimal" placeholder="p. ex. 0.02" aria-label="Ample del rectangle en metres">
+          </div>
+          <div id="area-rectangle-2" hidden>
+            <label for="alt">Alt [m]</label>
+            <input id="alt" type="number" step="any" inputmode="decimal" placeholder="p. ex. 0.01" aria-label="Alt del rectangle en metres">
+          </div>
+          <!-- Cercle -->
+          <div id="area-cercle" hidden>
+            <label for="radi">Radi r [m]</label>
+            <input id="radi" type="number" step="any" inputmode="decimal" placeholder="p. ex. 0.005" aria-label="Radi del cercle en metres">
+          </div>
+        </div>
+        <div id="msg-area" class="error" role="alert" aria-live="assertive"></div>
+      </div>
+
+      <!-- FORÇA, LONGITUDS I LÍMIT ELÀSTIC -->
+      <div class="grid cols-2">
+        <div class="row">
+          <label for="forca">Força F [N]</label>
+          <input id="forca" type="number" step="any" inputmode="decimal" placeholder="p. ex. 1200" aria-label="Força aplicada en newtons">
+          <div id="msg-forca" class="error" role="alert"></div>
+        </div>
+        <div class="row">
+          <div class="grid cols-2">
+            <div>
+              <label for="L0">Longitud inicial L₀ [m]</label>
+              <input id="L0" type="number" step="any" inputmode="decimal" placeholder="p. ex. 1.2" aria-label="Longitud inicial">
+            </div>
+            <div>
+              <label for="dL">Increment de longitud ΔL [m]</label>
+              <input id="dL" type="number" step="any" inputmode="decimal" placeholder="p. ex. 0.003" aria-label="Increment de longitud">
+            </div>
+          </div>
+          <div id="msg-l" class="error" role="alert"></div>
+        </div>
+      </div>
+
+      <div class="row">
+        <label>Límit elàstic E</label>
+        <div class="grid cols-3">
+          <div class="control">
+            <input id="E" type="number" step="any" inputmode="decimal" placeholder="p. ex. 210" aria-label="Valor de E">
+          </div>
+          <div class="segwrap" aria-label="Unitat de E">
+            <div class="seg" id="segUnit">
+              <div class="pill" aria-hidden="true"></div>
+              <input type="radio" name="unitE" id="u-pa" value="Pa" />
+              <label for="u-pa" data-index="0">Pa</label>
+              <input type="radio" name="unitE" id="u-mpa" value="MPa" checked />
+              <label for="u-mpa" data-index="1">MPa</label>
+              <input type="radio" name="unitE" id="u-gpa" value="GPa" />
+              <label for="u-gpa" data-index="2">GPa</label>
+            </div>
+          </div>
+          <div>
+            <label for="E-range">Ajust fi</label>
+            <input id="E-range" type="range" min="0" max="1000" step="1" aria-label="Control lliscant per al valor de E">
+          </div>
+        </div>
+        <div id="msg-e" class="error" role="alert"></div>
+      </div>
+
+      <!-- BOTONS -->
+      <div class="btns" style="margin-top:6px">
+        <button id="calc" aria-label="Calcular resultats">Calcular</button>
+        <button id="reset" aria-label="Reiniciar valors" type="button">Reset</button>
+      </div>
+
+      <!-- RESULTATS -->
+      <div class="row" style="margin-top:16px">
+        <label>Resultats</label>
+        <div class="stats" aria-live="polite">
+          <div class="stat"><div class="k">Àrea efectiva A [m²]</div><div class="v" id="out-area">—</div></div>
+          <div class="stat"><div class="k">Esforç σ [Pa]</div><div class="v" id="out-sigma-pa">—</div></div>
+          <div class="stat"><div class="k">Esforç σ [MPa]</div><div class="v" id="out-sigma-mpa">—</div></div>
+          <div class="stat"><div class="k">Esforç σ [GPa]</div><div class="v" id="out-sigma-gpa">—</div></div>
+          <div class="stat"><div class="k">Allargament ε [—]</div><div class="v" id="out-eps">—</div></div>
+          <div class="stat"><div class="k">Allargament ε [%]</div><div class="v" id="out-eps-pct">—</div></div>
+          <div class="stat"><div class="k">Límit elàstic E [Pa]</div><div class="v" id="out-e-pa">—</div></div>
+        </div>
+
+        <!-- Visual comparador σ vs E -->
+        <div style="margin-top:14px">
+          <div class="viz" role="img" aria-label="Comparació visual entre σ i E">
+            <div class="bar" id="viz-bar" aria-hidden="true"></div>
+            <div class="ref" id="viz-ref" aria-hidden="true" style="left:80%"></div>
+            <div class="viz-label">
+              <span>0</span>
+              <span id="viz-mid">50%</span>
+              <span>100% de E</span>
+            </div>
+          </div>
+          <div style="margin-top:10px; display:flex; align-items:center; gap:8px">
+            <span id="badge" class="chip" aria-live="polite">—</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- CONVERSIONS RÀPIDES -->
+      <div class="row" style="margin-top:14px">
+        <label>Conversions ràpides (Pa ⇄ MPa ⇄ GPa)</label>
+        <div class="grid cols-3">
+          <div>
+            <label for="conv-pa">Pa</label>
+            <input id="conv-pa" type="number" step="any" inputmode="decimal" placeholder="p. ex. 210000000000">
+          </div>
+          <div>
+            <label for="conv-mpa">MPa</label>
+            <input id="conv-mpa" type="number" step="any" inputmode="decimal" placeholder="p. ex. 210000">
+          </div>
+          <div>
+            <label for="conv-gpa">GPa</label>
+            <input id="conv-gpa" type="number" step="any" inputmode="decimal" placeholder="p. ex. 210">
+          </div>
+        </div>
+      </div>
+
+    </section>
+
+    <footer>Fet per Juan Arambul com a complement al tema d'Estructures i Esforços</footer>
+  </main>
+
+<script>
+/* ==========================================================
+   UTILS · format numèric ca-ES i clamp/lerp (interaccions)
+   ========================================================== */
+const fmt = (n, opts={}) => {
+  if (!isFinite(n)) return '—';
+  return new Intl.NumberFormat('ca-ES', Object.assign({maximumFractionDigits: 6}, opts)).format(n);
+};
+const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+const lerp = (a, b, t) => a + (b-a)*t;
+
+/* ==========================================================
+   SEGMENTED CONTROL · píndola animada
+   ========================================================== */
+function initSegmented(segEl){
+  const pill = segEl.querySelector('.pill');
+  const labels = [...segEl.querySelectorAll('label')];
+  const inputs = [...segEl.querySelectorAll('input[type=radio]')];
+
+  function positionPill(){
+    const idx = inputs.findIndex(r => r.checked);
+    const target = labels[idx];
+    const r = target.getBoundingClientRect();
+    const sr = segEl.getBoundingClientRect();
+    pill.style.left = (target.offsetLeft)+'px';
+    pill.style.width = (r.width)+'px';
+  }
+  inputs.forEach(r=>r.addEventListener('change', positionPill));
+  window.addEventListener('resize', positionPill, {passive:true});
+  positionPill();
+}
+initSegmented(document.getElementById('segArea'));
+initSegmented(document.getElementById('segUnit'));
+
+/* ==========================================================
+   REFERÈNCIES D’ENTRADA
+   ========================================================== */
+const el = {
+  // modes d’àrea
+  areaMode: () => document.querySelector('input[name=areaMode]:checked').value,
+  area: document.getElementById('area'),
+  ample: document.getElementById('ample'),
+  alt: document.getElementById('alt'),
+  radi: document.getElementById('radi'),
+  msgArea: document.getElementById('msg-area'),
+
+  // força i longituds
+  forca: document.getElementById('forca'),
+  L0: document.getElementById('L0'),
+  dL: document.getElementById('dL'),
+  msgForca: document.getElementById('msg-forca'),
+  msgL: document.getElementById('msg-l'),
+
+  // E + unitat + slider sincronitzat
+  E: document.getElementById('E'),
+  ERange: document.getElementById('E-range'),
+  unitE: () => document.querySelector('input[name=unitE]:checked').value,
+  msgE: document.getElementById('msg-e'),
+
+  // botons
+  calc: document.getElementById('calc'),
+  reset: document.getElementById('reset'),
+
+  // sortides
+  outA: document.getElementById('out-area'),
+  outSigPa: document.getElementById('out-sigma-pa'),
+  outSigMPa: document.getElementById('out-sigma-mpa'),
+  outSigGPa: document.getElementById('out-sigma-gpa'),
+  outEps: document.getElementById('out-eps'),
+  outEpsPct: document.getElementById('out-eps-pct'),
+  outEPa: document.getElementById('out-e-pa'),
+  vizBar: document.getElementById('viz-bar'),
+  vizRef: document.getElementById('viz-ref'),
+  vizMid: document.getElementById('viz-mid'),
+  badge: document.getElementById('badge'),
+
+  // conversions
+  cPa: document.getElementById('conv-pa'),
+  cMPa: document.getElementById('conv-mpa'),
+  cGPa: document.getElementById('conv-gpa'),
+};
+
+/* ==========================================================
+   MOSTRAR BLOCS D’ÀREA segons mode
+   ========================================================== */
+const blocks = {
+  directa: ['area-directa'],
+  rectangle: ['area-rectangle','area-rectangle-2'],
+  cercle: ['area-cercle']
+};
+function updateAreaBlocks(){
+  document.getElementById('msg-area').textContent = '';
+  Object.values(blocks).flat().forEach(id=>{
+    const div = document.getElementById(id);
+    div.hidden = true;
+  });
+  blocks[el.areaMode()].forEach(id=>{
+    document.getElementById(id).hidden = false;
+  });
+}
+document.querySelectorAll('input[name=areaMode]').forEach(r=>r.addEventListener('change', updateAreaBlocks));
+updateAreaBlocks();
+
+/* ==========================================================
+   SYNC NUMBER <-> RANGE per a E (patró d’interacció)
+   ========================================================== */
+function rangeMaxForUnit(unit){
+  // escales útils per a alumnat
+  if(unit==='Pa') return 2e11;      // fins 200 GPa
+  if(unit==='MPa') return 400000;   // 400.000 MPa = 400 GPa
+  if(unit==='GPa') return 400;      // 400 GPa
+  return 1000;
+}
+
+function syncRangeFromNumber(){
+  const unit = el.unitE();
+  const val = parseFloat(el.E.value);
+  const max = rangeMaxForUnit(unit);
+  el.ERange.max = 1000; // slider de 0..1000
+  const t = isFinite(val) && max>0 ? clamp(val/max,0,1) : 0;
+  el.ERange.value = Math.round(t*1000);
+}
+function syncNumberFromRange(){
+  const unit = el.unitE();
+  const max = rangeMaxForUnit(unit);
+  const t = el.ERange.value/1000;
+  const val = t*max;
+  el.E.value = Number(val.toFixed(6));
+}
+el.E.addEventListener('input', syncRangeFromNumber);
+el.ERange.addEventListener('input', syncNumberFromRange);
+document.querySelectorAll('input[name=unitE]').forEach(r=>{
+  r.addEventListener('change', ()=>{
+    // mantenim el mateix % quan canvia la unitat
+    const t = el.ERange.value/1000;
+    const max = rangeMaxForUnit(el.unitE());
+    el.E.value = Number((t*max).toFixed(6));
+  });
+});
+
+/* ==========================================================
+   CONVERSIONS (MPa/GPa → Pa i viceversa)
+   ========================================================== */
+function setConv(from){
+  const pa = el.cPa, mpa = el.cMPa, gpa = el.cGPa;
+  if(from==='Pa'){
+    const v = parseFloat(pa.value);
+    if(!isFinite(v)) return;
+    mpa.value = v/1e6;
+    gpa.value = v/1e9;
+  }else if(from==='MPa'){
+    const v = parseFloat(mpa.value);
+    if(!isFinite(v)) return;
+    pa.value = v*1e6;
+    gpa.value = v/1e3;
+  }else if(from==='GPa'){
+    const v = parseFloat(gpa.value);
+    if(!isFinite(v)) return;
+    pa.value = v*1e9;
+    mpa.value = v*1e3;
+  }
+}
+el.cPa.addEventListener('input', ()=>setConv('Pa'));
+el.cMPa.addEventListener('input', ()=>setConv('MPa'));
+el.cGPa.addEventListener('input', ()=>setConv('GPa'));
+
+/* ==========================================================
+   VALIDACIÓ BÀSICA
+   ========================================================== */
+function setError(elm, msg){ elm.textContent = msg || '' }
+function readArea(){
+  const mode = el.areaMode();
+  if(mode==='directa'){
+    const A = parseFloat(el.area.value);
+    if(!(A>0)) { setError(el.msgArea,'Indica una àrea A vàlida (> 0).'); return null; }
+    setError(el.msgArea,'');
+    return A;
+  }
+  if(mode==='rectangle'){
+    const a = parseFloat(el.ample.value);
+    const h = parseFloat(el.alt.value);
+    if(!(a>0 && h>0)) { setError(el.msgArea,'Indica ample i alt (> 0).'); return null; }
+    setError(el.msgArea,'');
+    return a*h;
+  }
+  if(mode==='cercle'){
+    const r = parseFloat(el.radi.value);
+    if(!(r>0)) { setError(el.msgArea,'Indica un radi r (> 0).'); return null; }
+    setError(el.msgArea,'');
+    return Math.PI*r*r;
+  }
+  return null;
+}
+function readForce(){
+  const F = parseFloat(el.forca.value);
+  if(!(F>0)){ setError(el.msgForca,'La força F ha de ser > 0.'); return null; }
+  setError(el.msgForca,''); return F;
+}
+function readLengths(){
+  const L0 = parseFloat(el.L0.value);
+  const dL = parseFloat(el.dL.value);
+  if(!(L0>0)){ setError(el.msgL,'L₀ ha de ser > 0.'); return null; }
+  if(!isFinite(dL)){ setError(el.msgL,'Indica ΔL (pot ser 0).'); return null; }
+  setError(el.msgL,''); return {L0,dL};
+}
+function readE(){
+  const E = parseFloat(el.E.value);
+  const unit = el.unitE();
+  if(!(E>0)){ setError(el.msgE,'E ha de ser > 0.'); return null; }
+  setError(el.msgE,'');
+  // passem E a Pa
+  let Epa = E;
+  if(unit==='MPa') Epa = E*1e6;
+  if(unit==='GPa') Epa = E*1e9;
+  return {Epa, unit};
+}
+
+/* ==========================================================
+   CÀLCUL PRINCIPAL
+   ========================================================== */
+function calcular(){
+  const A = readArea();
+  const F = readForce();
+  const Ls = readLengths();
+  const Eobj = readE();
+  if([A,F,Ls,Eobj].some(v=>v===null)) return;
+
+  const sigma = F/A;            // Pa
+  const eps = Ls.dL / Ls.L0;    // — unitless
+
+  // sortides
+  el.outA.textContent = fmt(A);
+  el.outSigPa.textContent = fmt(sigma);
+  el.outSigMPa.textContent = fmt(sigma/1e6);
+  el.outSigGPa.textContent = fmt(sigma/1e9);
+  el.outEps.textContent = fmt(eps,{maximumFractionDigits:8});
+  el.outEpsPct.textContent = fmt(eps*100,{maximumFractionDigits:4});
+  el.outEPa.textContent = fmt(Eobj.Epa);
+
+  // comparació σ vs E
+  const ratio = sigma / Eobj.Epa;
+  const pct = clamp(ratio,0,1)*100; // per a la barra (cap a 100%)
+  el.vizBar.style.width = pct+'%';
+
+  // línia discontínua a 100% de E
+  el.vizRef.style.left = 'calc(100% - 1px)';
+  el.vizMid.textContent = '50%';
+
+  // missatge d’estat
+  let state = '';
+  if (Math.abs(ratio-1) < 1e-12){ state = 'En perill · σ = E'; }
+  else if (ratio < 1){ state = 'Suporta · σ < E'; }
+  else { state = 'Es trenca · σ > E'; }
+  el.badge.textContent = `${state}  (σ/E = ${fmt(ratio,{maximumFractionDigits:6})})`;
+}
+
+el.calc.addEventListener('click', calcular);
+
+/* ==========================================================
+   RESET
+   ========================================================== */
+function doReset(){
+  // buidem inputs
+  [el.area, el.ample, el.alt, el.radi, el.forca, el.L0, el.dL, el.E, el.cPa, el.cMPa, el.cGPa].forEach(i=>i.value='');
+  // reset selectors
+  document.getElementById('md-directa').checked = true;
+  document.getElementById('u-mpa').checked = true;
+  updateAreaBlocks();
+  initSegmented(document.getElementById('segArea'));
+  initSegmented(document.getElementById('segUnit'));
+  // reset slider / missatges
+  el.ERange.value = 0;
+  [el.msgArea, el.msgForca, el.msgL, el.msgE].forEach(m=>m.textContent='');
+  // reset sortides
+  ['out-area','out-sigma-pa','out-sigma-mpa','out-sigma-gpa','out-eps','out-eps-pct','out-e-pa']
+    .forEach(id=>document.getElementById(id).textContent='—');
+  el.vizBar.style.width = '0%';
+  el.badge.textContent = '—';
+}
+el.reset.addEventListener('click', doReset);
+
+/* ==========================================================
+   ACCESSIBILITAT: avís live quan es canvia mode d’àrea
+   ========================================================== */
+document.getElementById('segArea').addEventListener('change', ()=>{
+  const m = el.areaMode();
+  const map = {directa:'àrea directa en m²', rectangle:'dimensions de rectangle', cercle:'radi de cercle'};
+  el.msgArea.textContent = `Mode d’entrada: ${map[m]}.`;
+  setTimeout(()=>el.msgArea.textContent='', 1500);
+});
+
+/* ==========================================================
+   VALORS DEMO (opcional per facilitar proves)
+   ========================================================== */
+(function seed(){
+  // Exemple: barra acer: E ≈ 210 GPa
+  el.forca.value = 1200;
+  el.area.value = 0.0005;
+  el.L0.value = 1.2;
+  el.dL.value = 0.003;
+  document.getElementById('u-gpa').checked = true;
+  el.E.value = 210; // 210 GPa
+  syncRangeFromNumber();
+})();
+</script>
+</body>
+</html>

--- a/apps/esforcos-mobil.html
+++ b/apps/esforcos-mobil.html
@@ -1,0 +1,397 @@
+<!DOCTYPE html>
+<html lang="ca">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Esforços versió mòbil · Vibe Coding Educatiu UI</title>
+  <link rel="stylesheet" href="../assets/css/shell.css" />
+  <style>
+    :root{
+      --bg-top:#0b1226;
+      --bg-bottom:#0f172a;
+      --card:rgba(17,24,39,.85);
+      --border:rgba(148,163,184,.18);
+      --border-strong:rgba(148,163,184,.32);
+      --text:#e5e7eb;
+      --muted:#94a3b8;
+      --accent:#38bdf8;
+      --accent-2:#a78bfa;
+      --danger:#ef4444;
+      --radius-lg:22px;
+      --radius:14px;
+      --shadow:0 24px 60px rgba(2,6,23,.55);
+      --dur:280ms;
+      --ease:cubic-bezier(.22,1,.36,1);
+    }
+    *{box-sizing:border-box}
+    body{
+      margin:0;
+      font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans";
+      min-height:100vh;
+      background:linear-gradient(to bottom,var(--bg-top),var(--bg-bottom));
+      color:var(--text);
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+    }
+    main{
+      width:100%;
+      max-width:540px;
+      padding:24px 18px 120px;
+      display:flex;
+      flex-direction:column;
+      gap:24px;
+    }
+    .card{
+      background:var(--card);
+      border:1px solid var(--border);
+      border-radius:var(--radius-lg);
+      box-shadow:var(--shadow);
+      backdrop-filter:blur(10px);
+      -webkit-backdrop-filter:blur(10px);
+      padding:28px 22px;
+      display:flex;
+      flex-direction:column;
+      gap:24px;
+    }
+    header h1{
+      margin:0;
+      font-size:clamp(26px,6vw,32px);
+      font-weight:800;
+      letter-spacing:.3px;
+    }
+    header p{
+      margin:8px 0 0;
+      color:var(--muted);
+      font-size:clamp(16px,4.8vw,18px);
+      line-height:1.5;
+    }
+    .block-title{
+      margin:0;
+      font-size:clamp(18px,5vw,22px);
+      font-weight:700;
+    }
+    .formula-note{
+      margin:6px 0 0;
+      color:var(--muted);
+      font-size:15px;
+      line-height:1.5;
+    }
+    .formula-display{
+      display:flex;
+      flex-direction:column;
+      gap:18px;
+    }
+    .sigma-identity{
+      font-size:clamp(20px,6vw,26px);
+      font-weight:700;
+      display:flex;
+      align-items:center;
+      gap:8px;
+    }
+    .fraction{
+      display:flex;
+      flex-direction:column;
+      align-items:flex-start;
+      gap:16px;
+      padding:18px;
+      border:1px solid var(--border);
+      border-radius:var(--radius);
+      background:rgba(2,6,23,.55);
+    }
+    .fraction-label{
+      font-size:18px;
+      font-weight:700;
+    }
+    .fraction-line{
+      display:flex;
+      gap:12px;
+      width:100%;
+      align-items:flex-start;
+    }
+    .fraction-stack{
+      display:flex;
+      flex-direction:column;
+      gap:10px;
+      width:100%;
+      max-width:220px;
+    }
+    .fraction-stack .row{
+      display:flex;
+      align-items:center;
+      gap:8px;
+      background:rgba(15,23,42,.72);
+      border:1px solid var(--border-strong);
+      border-radius:var(--radius);
+      padding:10px 14px;
+    }
+    .fraction-stack input{
+      flex:1;
+      max-width:130px;
+      border:0;
+      background:transparent;
+      color:var(--text);
+      font-size:20px;
+      font-weight:700;
+      text-align:right;
+      font-variant-numeric:tabular-nums;
+      outline:none;
+    }
+    .fraction-stack input::placeholder{color:rgba(148,163,184,.5);}
+    .unit{
+      color:var(--muted);
+      font-size:16px;
+      font-weight:600;
+      white-space:nowrap;
+    }
+    .sigma-output{
+      display:flex;
+      flex-direction:column;
+      gap:4px;
+      align-items:flex-start;
+    }
+    .result-label{font-size:14px;color:var(--muted);letter-spacing:.3px;text-transform:uppercase;}
+    .result-value{
+      font-size:26px;
+      font-weight:800;
+      letter-spacing:.4px;
+      font-variant-numeric:tabular-nums;
+    }
+    .area-blocks{
+      display:grid;
+      gap:18px;
+    }
+    .area-card{
+      display:flex;
+      flex-direction:column;
+      gap:14px;
+      padding:18px;
+      border-radius:var(--radius);
+      border:1px solid var(--border);
+      background:rgba(2,6,23,.55);
+    }
+    .area-card h3{
+      margin:0;
+      font-size:18px;
+      font-weight:700;
+    }
+    .input-pair{
+      display:grid;
+      grid-template-columns:1fr 1fr;
+      gap:12px;
+    }
+    .input-pair label,
+    .single-input label{
+      display:grid;
+      gap:6px;
+      font-size:15px;
+      color:var(--muted);
+    }
+    .input-pair input,
+    .single-input input{
+      width:100%;
+      border:1px solid var(--border-strong);
+      border-radius:var(--radius);
+      background:rgba(15,23,42,.72);
+      color:var(--text);
+      font-size:18px;
+      padding:12px;
+      font-variant-numeric:tabular-nums;
+      outline:none;
+      transition:border-color var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
+    }
+    .input-pair input:focus,
+    .single-input input:focus{
+      border-color:var(--accent);
+      box-shadow:0 0 0 3px rgba(56,189,248,.18);
+    }
+    .area-result{
+      font-size:20px;
+      font-weight:700;
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      background:rgba(15,23,42,.8);
+      border:1px solid var(--border);
+      border-radius:var(--radius);
+      padding:12px 16px;
+      font-variant-numeric:tabular-nums;
+    }
+    .area-result span:last-child{color:var(--accent);}
+    footer{
+      margin-top:12px;
+      color:var(--muted);
+      font-size:13px;
+      text-align:center;
+    }
+    .bottom-nav{
+      position:fixed;
+      bottom:0;
+      left:0;
+      right:0;
+      display:flex;
+      justify-content:center;
+      padding:12px 16px 24px;
+      pointer-events:none;
+    }
+    .bottom-nav .back-link{
+      pointer-events:auto;
+      width:100%;
+      max-width:360px;
+      justify-content:center;
+    }
+    @media (min-width:641px){
+      main{padding-bottom:96px;}
+      .bottom-nav{padding-bottom:28px;}
+    }
+  </style>
+</head>
+<body>
+  <nav class="top-nav" aria-label="Navegació principal">
+    <a class="logo" href="../index.html"><span>VC</span>Aula d'Estructures</a>
+    <a class="back-link" href="../index.html" aria-label="Torna a la portada de l'Aula d'Estructures">← Torna a l'inici</a>
+  </nav>
+  <main>
+    <section class="card" aria-labelledby="titol-app">
+      <header>
+        <h1 id="titol-app">Esforços versió mòbil</h1>
+        <p>Calculadora d'esforç de tracció o compressió amb controls grans i lectura còmoda per a pantalles verticals.</p>
+      </header>
+
+      <div class="formula-display" aria-labelledby="calc-title">
+        <h2 id="calc-title" class="block-title">Calculadora d'esforç de tracció o compressió</h2>
+        <div class="sigma-identity">σ = F / A</div>
+        <p class="formula-note">Introdueix la força en newtons i l'àrea en metres quadrats. σ es mostrarà en pascals (Pa).</p>
+        <div class="fraction" role="group" aria-label="Càlcul de l'esforç">
+          <div class="fraction-line">
+            <span class="fraction-label">σ =</span>
+            <div class="fraction-stack">
+              <label class="row" for="forca">
+                <input id="forca" type="number" inputmode="decimal" placeholder="F" aria-label="Força en newtons" />
+                <span class="unit">N</span>
+              </label>
+              <label class="row" for="area">
+                <input id="area" type="number" inputmode="decimal" placeholder="A" aria-label="Àrea en metres quadrats" />
+                <span class="unit">m²</span>
+              </label>
+            </div>
+          </div>
+          <div class="sigma-output" aria-live="polite">
+            <span class="result-label">Resultat</span>
+            <span class="result-value" id="sigma">—</span>
+            <span class="unit">Pa</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="area-blocks" aria-labelledby="areas-title">
+        <h2 id="areas-title" class="block-title">Càlcul d'àrees</h2>
+
+        <div class="area-card" aria-labelledby="rect-title">
+          <h3 id="rect-title">Rectangle</h3>
+          <div class="input-pair">
+            <label for="ample">
+              Amplada (m)
+              <input id="ample" type="number" inputmode="decimal" placeholder="p. ex. 0.40" aria-label="Amplada en metres" />
+            </label>
+            <label for="alt">
+              Altura (m)
+              <input id="alt" type="number" inputmode="decimal" placeholder="p. ex. 0.15" aria-label="Altura en metres" />
+            </label>
+          </div>
+          <div class="area-result">
+            <span>A<sub>rectangle</sub></span>
+            <span id="area-rect">— m²</span>
+          </div>
+        </div>
+
+        <div class="area-card" aria-labelledby="cercle-title">
+          <h3 id="cercle-title">Cercle</h3>
+          <div class="single-input">
+            <label for="radi">
+              Radi (m)
+              <input id="radi" type="number" inputmode="decimal" placeholder="p. ex. 0.08" aria-label="Radi en metres" />
+            </label>
+          </div>
+          <div class="area-result">
+            <span>A<sub>cercle</sub></span>
+            <span id="area-cercle">— m²</span>
+          </div>
+        </div>
+      </div>
+
+      <footer>Fet per Juan Arambul com a complement al tema d'Estructures i Esforços</footer>
+    </section>
+  </main>
+
+  <div class="bottom-nav" aria-hidden="false">
+    <a class="back-link" href="../index.html" aria-label="Torna a l'inici">← Torna a l'inici</a>
+  </div>
+
+  <script>
+    const fmt = (n, opts={}) => {
+      if (!isFinite(n)) return '—';
+      const base = {maximumFractionDigits:4};
+      return new Intl.NumberFormat('ca-ES', {...base, ...opts}).format(n);
+    };
+
+    const forceInput = document.getElementById('forca');
+    const areaInput = document.getElementById('area');
+    const sigmaOut = document.getElementById('sigma');
+
+    const ampleInput = document.getElementById('ample');
+    const altInput = document.getElementById('alt');
+    const rectOut = document.getElementById('area-rect');
+
+    const radiInput = document.getElementById('radi');
+    const circleOut = document.getElementById('area-cercle');
+
+    const inputs = [forceInput, areaInput, ampleInput, altInput, radiInput];
+    inputs.forEach(el => el.addEventListener('input', handleInput));
+
+    function handleInput(){
+      computeSigma();
+      computeAreas();
+    }
+
+    function computeSigma(){
+      const F = parseFloat(forceInput.value);
+      const A = parseFloat(areaInput.value);
+      if (isFinite(F) && isFinite(A) && A !== 0){
+        const sigma = F / A;
+        sigmaOut.textContent = fmt(sigma, {maximumFractionDigits:6});
+      } else {
+        sigmaOut.textContent = '—';
+      }
+    }
+
+    function computeAreas(){
+      const ample = parseFloat(ampleInput.value);
+      const alt = parseFloat(altInput.value);
+      if (isFinite(ample) && ample > 0 && isFinite(alt) && alt > 0){
+        const area = ample * alt;
+        rectOut.textContent = `${fmt(area)} m²`;
+      } else {
+        rectOut.textContent = '— m²';
+      }
+
+      const radi = parseFloat(radiInput.value);
+      if (isFinite(radi) && radi > 0){
+        const areaC = Math.PI * radi * radi;
+        circleOut.textContent = `${fmt(areaC)} m²`;
+      } else {
+        circleOut.textContent = '— m²';
+      }
+    }
+
+    // Valors d'exemple per facilitar proves
+    forceInput.value = '1200';
+    areaInput.value = '0.0005';
+    ampleInput.value = '0.40';
+    altInput.value = '0.15';
+    radiInput.value = '0.08';
+
+    handleInput();
+  </script>
+</body>
+</html>

--- a/apps/simulador-esforcos.html
+++ b/apps/simulador-esforcos.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<html lang="ca">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Simulador d'Esforços: Tracció i Compressió</title>
+  <link rel="stylesheet" href="../assets/css/shell.css" />
+  <style>
+    :root{
+      --bg:#0f172a; /* slate-900 */
+      --card:#111827; /* gray-900 */
+      --muted:#94a3b8; /* slate-400 */
+      --text:#e5e7eb; /* gray-200 */
+      --accent:#38bdf8; /* sky-400 */
+      --ok:#22c55e; /* green-500 */
+      --warn:#f59e0b; /* amber-500 */
+      --err:#ef4444; /* red-500 */
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    body{
+      margin:0;
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
+      background:linear-gradient(180deg,#0b1226,#0f172a);
+      color:var(--text);
+      min-height:100vh;
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      justify-content:flex-start;
+      padding:24px 24px 32px;
+      gap:16px;
+    }
+    .app{max-width:960px; width:100%; margin:0 auto;}
+    .card{background:rgba(17,24,39,.75); backdrop-filter: blur(6px); border:1px solid rgba(148,163,184,.15); border-radius:16px; padding:20px; box-shadow: 0 10px 30px rgba(2,6,23,.4); display:grid; gap:18px;}
+    h1{margin:0 0 8px; font-size:clamp(22px,2.8vw,32px); letter-spacing:.2px}
+    p.sub{margin:0 0 16px; color:var(--muted)}
+    fieldset{border:0; padding:0; margin:0 0 12px; display:flex; gap:12px; flex-wrap:wrap}
+    .segmented{display:inline-flex; background:#0b1226; border:1px solid rgba(148,163,184,.2); border-radius:999px; overflow:hidden}
+    .segmented input{display:none}
+    .segmented label{padding:10px 14px; cursor:pointer; color:var(--muted); user-select:none}
+    .segmented input:checked + label{background:var(--accent); color:#06121b; font-weight:600}
+    .row{display:flex; gap:14px; flex-wrap:wrap; align-items:end}
+    .field{flex:1; min-width:220px}
+    .field label{display:block; font-size:14px; color:var(--muted); margin:0 0 6px}
+    input[type="number"], input[type="range"]{width:100%}
+    input[type="number"]{background:#0b1226; color:var(--text); border:1px solid rgba(148,163,184,.3); border-radius:10px; padding:10px 12px; font-size:16px}
+    input[type="range"]{accent-color:var(--accent)}
+    button{background:var(--accent); color:#06121b; border:0; padding:12px 16px; border-radius:12px; font-weight:700; cursor:pointer}
+    button:disabled{opacity:.5; cursor:not-allowed}
+    .error{color:var(--err); font-size:14px; min-height:1.2em}
+
+    .canvas{margin-top:20px; background:radial-gradient(1200px 600px at 50% -20%, rgba(56,189,248,.15), transparent 60%), linear-gradient(180deg, rgba(255,255,255,.04), rgba(255,255,255,.02)); border:1px solid rgba(148,163,184,.2); border-radius:16px; padding:16px}
+    .legend{display:flex; gap:16px; flex-wrap:wrap; align-items:center; justify-content:space-between; color:var(--muted); font-size:14px}
+    .stats{display:grid; grid-template-columns: repeat(auto-fit,minmax(180px,1fr)); gap:10px; margin-top:10px}
+    .stat{background:rgba(2,6,23,.5); border:1px solid rgba(148,163,184,.15); border-radius:12px; padding:10px}
+    .stat .k{color:var(--muted); font-size:12px}
+    .stat .v{font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size:16px}
+
+    /* Contenidor de la viga */
+    .beam-wrap{display:flex; align-items:center; justify-content:center; padding:20px}
+    svg{max-width:100%; height:auto}
+    .note{color:var(--muted); font-size:12px; margin-top:6px}
+    .footer{margin-top:18px; color:var(--muted); font-size:13px}
+    .app{margin-top:8px;}
+  </style>
+</head>
+<body>
+  <nav class="top-nav" aria-label="Navegació principal">
+    <a class="logo" href="../index.html"><span>VC</span>Aula d'Estructures</a>
+    <a class="back-link" href="../index.html" aria-label="Torna a la portada">← Torna a l'inici</a>
+  </nav>
+  <div class="app card">
+    <h1>Simulador d'Esforços: Tracció i Compressió</h1>
+    <p class="sub">Tria el tipus d'esforç, introdueix la força (10 000 N – 200 000 N) i observa com canvia la longitud de la viga. L'animació està <em>amplificada visualment</em> per fer visible la deformació, però també es mostren els valors teòrics.</p>
+
+    <form id="form">
+      <fieldset aria-label="Tipus d'esforç">
+        <div class="segmented" role="tablist" aria-label="Tipus d'esforç">
+          <input type="radio" name="mode" id="tension" value="tension" checked>
+          <label for="tension">Tracció</label>
+          <input type="radio" name="mode" id="compression" value="compression">
+          <label for="compression">Compressió</label>
+        </div>
+      </fieldset>
+
+      <div class="row">
+        <div class="field">
+          <label for="force">Força aplicada (N)</label>
+          <input id="force" name="force" type="number" inputmode="numeric" min="10000" max="200000" step="1000" value="10000" required>
+          <div class="error" id="err"></div>
+        </div>
+        <div class="field">
+          <label for="forceRange">Ajust ràpid</label>
+          <input id="forceRange" type="range" min="10000" max="200000" step="1000" value="10000">
+        </div>
+        <div>
+          <button id="run" type="submit">Simula</button>
+          <button id="reset" type="button" aria-label="Reinicia">Reset</button>
+        </div>
+      </div>
+    </form>
+
+    <div class="canvas" aria-live="polite">
+      <div class="legend">
+        <div>
+          <strong>Viga rectangular</strong> · vista 2D · longitud inicial <span id="L0label"></span>
+        </div>
+        <div>
+          Material: <strong>Acer</strong> (E = <span id="Elabel"></span>) · Secció: <strong>50 mm × 50 mm</strong> (A = <span id="Alabel"></span>)
+        </div>
+      </div>
+
+      <div class="beam-wrap">
+        <!-- Escena SVG -->
+        <svg id="scene" viewBox="0 0 860 220" aria-label="Escena de viga">
+          <!-- suports -->
+          <g id="clamps" transform="translate(30,40)">
+            <rect id="clampLeft" x="-20" y="0" width="20" height="140" fill="#64748b" opacity="0.7"/>
+            <rect id="clampRight" x="780" y="0" width="20" height="140" fill="#64748b" opacity="0.7"/>
+          </g>
+
+          <!-- viga -->
+          <g id="beamGroup" transform="translate(30,40)">
+            <!-- Viga de referència (sense deformar) -->
+            <rect id="beamRef" x="0" y="40" width="800" height="60" rx="8"
+                  fill="none" stroke="rgba(148,163,184,.4)" stroke-dasharray="8 6" />
+            <!-- Viga activa -->
+            <rect id="beam" x="0" y="40" width="800" height="60" rx="8" 
+                  fill="url(#grad)" stroke="rgba(148,163,184,.6)" />
+          </g>
+
+          <!-- fletxes / marcadors -->
+          <g id="arrows" transform="translate(30,40)"></g>
+
+          <defs>
+            <linearGradient id="grad" x1="0%" x2="100%" y1="0%" y2="0%">
+              <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.9"/>
+              <stop offset="100%" stop-color="#a78bfa" stop-opacity="0.9"/>
+            </linearGradient>
+          </defs>
+        </svg>
+      </div>
+
+      <div class="stats">
+        <div class="stat"><div class="k">Tipus</div><div class="v" id="statMode">Tracció</div></div>
+        <div class="stat"><div class="k">F (N)</div><div class="v" id="statF">10 000</div></div>
+        <div class="stat"><div class="k">σ = F/A (Pa)</div><div class="v" id="statSigma">—</div></div>
+        <div class="stat"><div class="k">ε = σ/E (—)</div><div class="v" id="statEps">—</div></div>
+        <div class="stat"><div class="k">ΔL = ε·L (m)</div><div class="v" id="statDelta">—</div></div>
+        <div class="stat"><div class="k">Longitud final (m)</div><div class="v" id="statLf">—</div></div>
+      </div>
+
+      <p class="note">Nota: La deformació teòrica és molt petita per als materials reals. Per apreciar-la en pantalla, l'animació empra una <strong>amplificació visual</strong> que escala linealment entre 10 000 N (mínim visible) i 200 000 N (màxim visible), conservant la proporcionalitat.</p>
+    </div>
+
+    <div class="footer">
+      Fet per Juan Arambul com a complement al tema d'Estructures i Esforços
+    </div>
+  </div>
+
+  <script>
+    // ======== Paràmetres físics (pots canviar-los si vols) ========
+    const L0_m = 2.0;                 // Longitud inicial en metres
+    const A_m2 = 0.05 * 0.05;         // Secció: 50 mm x 50 mm = 0.05 m * 0.05 m = 0.0025 m^2
+    const E_Pa = 200e9;               // Mòdul de Young acer ~ 200 GPa
+
+    // Perquè es veja a la pantalla
+    const BEAM_PX_BASE = 800;         // amplada base de la viga en px (SVG)
+    const VISUAL_MAX_PX = 120;        // píxels extra (estirar) o a restar (contraure) a 200 kN
+    const VISUAL_MIN_FORCE = 10000;   // N
+    const VISUAL_MAX_FORCE = 200000;  // N
+
+    // Elements UI
+    const form = document.getElementById('form');
+    const forceInput = document.getElementById('force');
+    const forceRange = document.getElementById('forceRange');
+    const err = document.getElementById('err');
+    const resetBtn = document.getElementById('reset');
+
+    // Estadístiques
+    const statMode = document.getElementById('statMode');
+    const statF = document.getElementById('statF');
+    const statSigma = document.getElementById('statSigma');
+    const statEps = document.getElementById('statEps');
+    const statDelta = document.getElementById('statDelta');
+    const statLf = document.getElementById('statLf');
+
+    // Etiquetes de constants
+    document.getElementById('L0label').textContent = `${L0_m.toFixed(2)} m`;
+    document.getElementById('Elabel').textContent = `200 GPa`;
+    document.getElementById('Alabel').textContent = `${(A_m2).toFixed(4)} m²`;
+
+    // Escena SVG
+    const beam = document.getElementById('beam');
+    const beamRef = document.getElementById('beamRef');
+    const clampRight = document.getElementById('clampRight');
+    const arrows = document.getElementById('arrows');
+
+    // Estat
+    let mode = 'tension';
+    let F = 10000;
+
+    // Enllaça number <-> range
+    forceInput.addEventListener('input', () => {
+      forceRange.value = forceInput.value;
+    });
+    forceRange.addEventListener('input', () => {
+      forceInput.value = forceRange.value;
+    });
+
+    // Canvis de mode
+    form.addEventListener('change', (e)=>{
+      if(e.target.name === 'mode'){
+        mode = e.target.value; // 'tension' | 'compression'
+        updateScene();
+      }
+    });
+
+    form.addEventListener('submit', (e)=>{
+      e.preventDefault();
+      const val = Number(forceInput.value);
+      if(Number.isNaN(val) || val < 10000 || val > 200000){
+        err.textContent = 'Introdueix un valor entre 10 000 i 200 000 N';
+        return;
+      }
+      err.textContent = '';
+      F = val;
+      updateScene(true);
+    });
+
+    function lerp(a,b,t){ return a + (b-a)*t }
+    function clamp(x,min,max){ return Math.max(min, Math.min(max,x)) }
+
+    function numberFmt(x,dec=0){
+      return x.toLocaleString('ca-ES', {minimumFractionDigits:dec, maximumFractionDigits:dec});
+    }
+
+    function updateScene(animated=false){
+      // Càlculs teòrics
+      const sigma = F / A_m2;          // Pa
+      const eps = sigma / E_Pa;        // adimensional
+      const dL = eps * L0_m;           // m
+      const Lf = L0_m + (mode==='tension' ? dL : -dL);
+
+      // Estadístiques
+      statMode.textContent = mode === 'tension' ? 'Tracció' : 'Compressió';
+      statF.textContent = numberFmt(F);
+      statSigma.textContent = sigma.toExponential(3).replace('e','×10^');
+      statEps.textContent = eps.toExponential(3).replace('e','×10^');
+      statDelta.textContent = `${(dL*1000).toFixed(3)} mm`;
+      statLf.textContent = `${Lf.toFixed(4)} m`;
+
+      // Escalat visual lineal entre 10k i 200k N
+      const t = clamp((F - VISUAL_MIN_FORCE) / (VISUAL_MAX_FORCE - VISUAL_MIN_FORCE), 0, 1);
+      const deltaPx = lerp(0, VISUAL_MAX_PX, t) * (mode==='tension' ? 1 : -1);
+
+      // Animació d'amplada de la viga i posició del suport dret
+      const targetWidth = clamp(BEAM_PX_BASE + deltaPx, 200, 980);
+      if(animated){
+        animateBeamAndClamp(beam, clampRight, targetWidth, 300);
+      } else {
+        beam.setAttribute('width', targetWidth);
+        clampRight.setAttribute('x', targetWidth - 20); // acompanya el límit dret de la viga
+      }
+
+      // Fletxes de càrrega
+      // Mantén la viga de referència sempre a dimensions originals
+      beamRef.setAttribute('width', BEAM_PX_BASE);
+
+      // Fletxes de càrrega col·locades als extrems actuals
+      drawArrows(mode);
+    }
+
+    function animateBeamAndClamp(rect, clamp, targetWidth, duration){
+      const startW = Number(rect.getAttribute('width')) || BEAM_PX_BASE;
+      const diffW = targetWidth - startW;
+      const t0 = performance.now();
+      function step(t){
+        const k = clamp01((t - t0)/duration);
+        const ease = 1 - Math.pow(1-k, 3); // easeOutCubic
+        const w = startW + diffW*ease;
+        rect.setAttribute('width', w);
+        clamp.setAttribute('x', w - 20);
+        if(k < 1) requestAnimationFrame(step);
+      }
+      requestAnimationFrame(step);
+    }
+
+    function clamp01(x){ return Math.max(0, Math.min(1, x)) }
+
+    function drawArrows(mode){
+      arrows.innerHTML = '';
+      const g = document.createElementNS('http://www.w3.org/2000/svg','g');
+      const mkArrow = (x,dir)=>{
+        const line = document.createElementNS('http://www.w3.org/2000/svg','line');
+        line.setAttribute('x1', x + (dir>0? -20:20));
+        line.setAttribute('y1', 70);
+        line.setAttribute('x2', x + (dir>0? -2:2));
+        line.setAttribute('y2', 70);
+        line.setAttribute('stroke', '#38bdf8');
+        line.setAttribute('stroke-width', 4);
+        line.setAttribute('stroke-linecap', 'round');
+        const tri = document.createElementNS('http://www.w3.org/2000/svg','polygon');
+        const pts = dir>0 ? `${x},70 ${x-10},64 ${x-10},76` : `${x},70 ${x+10},64 ${x+10},76`;
+        tri.setAttribute('points', pts);
+        tri.setAttribute('fill','#38bdf8');
+        g.appendChild(line); g.appendChild(tri);
+      }
+      if(mode==='tension'){
+        mkArrow(0, -1);   // esquerra cap enfora
+        mkArrow(Number(beam.getAttribute('width')), +1); // dreta cap enfora, al límit actual
+      } else {
+        mkArrow(0, +1);   // esquerra cap endins
+        mkArrow(Number(beam.getAttribute('width')), -1); // dreta cap endins
+      }
+      arrows.appendChild(g);
+    }
+
+    // Botó Reset
+    resetBtn.addEventListener('click', ()=>{
+      // Mode a Tracció
+      document.getElementById('tension').checked = true;
+      document.getElementById('compression').checked = false;
+      mode = 'tension';
+      // Força a mínim
+      F = 10000;
+      forceInput.value = '10000';
+      forceRange.value = '10000';
+      // Reposiciona viga i suport dret
+      beam.setAttribute('width', BEAM_PX_BASE);
+      clampRight.setAttribute('x', BEAM_PX_BASE - 20);
+      // Actualitza estadístiques i fletxes
+      updateScene(false);
+    });
+
+    // Inicialitza
+    updateScene(false);
+  </script>
+</body>
+</html>

--- a/assets/css/shell.css
+++ b/assets/css/shell.css
@@ -1,0 +1,93 @@
+:root{
+  --shell-max-width:1100px;
+}
+
+.site-nav,
+.top-nav{
+  width:100%;
+  max-width:var(--shell-max-width);
+  margin:0 auto;
+  padding:28px 24px 0;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:16px;
+  flex-wrap:wrap;
+  row-gap:12px;
+}
+
+.site-nav a.logo,
+.top-nav a.logo{
+  display:inline-flex;
+  align-items:center;
+  gap:10px;
+  text-decoration:none;
+  color:var(--text,#e5e7eb);
+  font-weight:800;
+  letter-spacing:.3px;
+  font-size:clamp(16px,2.8vw,20px);
+}
+
+.site-nav a.logo span,
+.top-nav a.logo span{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:32px;
+  height:32px;
+  border-radius:10px;
+  background:linear-gradient(135deg,rgba(56,189,248,.28),rgba(167,139,250,.24));
+  box-shadow:0 12px 28px rgba(56,189,248,.24);
+  color:#0b1226;
+  font-weight:700;
+  font-size:18px;
+}
+
+.site-nav a.jump-link{
+  color:var(--muted,#94a3b8);
+  text-decoration:none;
+  font-weight:600;
+  border:1px solid rgba(148,163,184,.22);
+  border-radius:999px;
+  padding:10px 16px;
+  background:rgba(15,23,42,.6);
+  transition:
+    transform var(--dur,300ms) var(--ease,cubic-bezier(.22,1,.36,1)),
+    border-color var(--dur,300ms) var(--ease,cubic-bezier(.22,1,.36,1));
+}
+
+.site-nav a.jump-link:hover{
+  transform:translateY(-1px);
+  border-color:rgba(148,163,184,.4);
+}
+
+.top-nav .back-link{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  color:var(--muted,#94a3b8);
+  text-decoration:none;
+  font-weight:600;
+  border:1px solid rgba(148,163,184,.22);
+  border-radius:999px;
+  padding:10px 16px;
+  background:rgba(15,23,42,.6);
+  transition:
+    transform var(--dur,300ms) var(--ease,cubic-bezier(.22,1,.36,1)),
+    border-color var(--dur,300ms) var(--ease,cubic-bezier(.22,1,.36,1)),
+    color var(--dur,300ms) var(--ease,cubic-bezier(.22,1,.36,1));
+  box-shadow:0 12px 24px rgba(2,6,23,.35);
+}
+
+.top-nav .back-link:hover{
+  transform:translateY(-1px);
+  border-color:rgba(56,189,248,.6);
+  color:var(--accent,#38bdf8);
+}
+
+@media (max-width:540px){
+  .site-nav,
+  .top-nav{
+    padding-inline:16px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,1 +1,148 @@
-<!doctype html><title>placeholder</title>
+<!DOCTYPE html>
+<html lang="ca">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Aula d'Estructures · Vibe Coding Educatiu UI</title>
+  <link rel="stylesheet" href="assets/css/shell.css" />
+  <style>
+    :root{
+      --bg-top:#0b1226;
+      --bg-bottom:#0f172a;
+      --card:rgba(17,24,39,.78);
+      --border:rgba(148,163,184,.18);
+      --border-strong:rgba(148,163,184,.35);
+      --text:#e5e7eb;
+      --muted:#94a3b8;
+      --accent:#38bdf8;
+      --accent-2:#a78bfa;
+      --shadow:0 18px 45px rgba(0,0,0,.42);
+      --radius:18px;
+      --dur:220ms;
+      --ease:cubic-bezier(.22,1,.36,1);
+    }
+    *{box-sizing:border-box}
+    body{
+      margin:0;
+      min-height:100vh;
+      font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans";
+      color:var(--text);
+      background:linear-gradient(to bottom,var(--bg-top),var(--bg-bottom));
+      display:flex;
+      flex-direction:column;
+    }
+    main{
+      width:100%;
+      max-width:1040px;
+      margin:0 auto;
+      padding:72px 24px 64px;
+      display:grid;
+      gap:36px;
+    }
+    header{
+      display:grid;
+      gap:12px;
+    }
+    h1{
+      margin:0;
+      font-size:clamp(32px,6vw,46px);
+      font-weight:800;
+      letter-spacing:.4px;
+    }
+    .intro{
+      margin:0;
+      max-width:720px;
+      color:var(--muted);
+      font-size:clamp(16px,3vw,18px);
+      line-height:1.6;
+    }
+    .apps-grid{
+      display:grid;
+      gap:20px;
+      grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+    }
+    .app-card{
+      display:flex;
+      flex-direction:column;
+      gap:14px;
+      background:var(--card);
+      border:1px solid var(--border);
+      border-radius:var(--radius);
+      padding:24px;
+      text-decoration:none;
+      color:var(--text);
+      box-shadow:var(--shadow);
+      transition:border-color var(--dur) var(--ease), transform var(--dur) var(--ease);
+    }
+    .app-card:hover,
+    .app-card:focus-visible{
+      border-color:var(--border-strong);
+      transform:translateY(-3px);
+      outline:none;
+    }
+    .app-icon{
+      width:56px;
+      height:56px;
+      border-radius:16px;
+      background:linear-gradient(135deg,var(--accent),var(--accent-2));
+      display:grid;
+      place-items:center;
+      font-size:26px;
+      font-weight:700;
+      color:#0b1226;
+    }
+    .app-card h2{
+      margin:0;
+      font-size:20px;
+      font-weight:700;
+    }
+    .app-card p{
+      margin:0;
+      color:var(--muted);
+      font-size:15px;
+      line-height:1.5;
+    }
+    footer{
+      text-align:center;
+      padding:0 24px 36px;
+      color:var(--muted);
+      font-size:13px;
+    }
+  </style>
+</head>
+<body>
+  <nav class="site-nav" aria-label="Navegació principal">
+    <a class="logo" href="index.html"><span>VC</span>Aula d'Estructures</a>
+  </nav>
+  <main>
+    <header>
+      <h1>Aula d'Estructures i Esforços</h1>
+      <p class="intro">Col·lecció d'eines interactives per experimentar amb tracció, compressió i càlculs d'esforços dins de les activitats de tecnologia. Clica una app per obrir-la.</p>
+    </header>
+
+    <section class="apps-grid" id="apps" aria-label="Llistat d'aplicacions">
+      <a class="app-card" href="apps/calculadora-traccio.html">
+        <div class="app-icon" aria-hidden="true">σ</div>
+        <h2>Calculadora d'Esforç de Tracció / Compressió</h2>
+        <p>Calcula tensió, deformació i conversions d'unitats amb diferents formes de secció.</p>
+      </a>
+      <a class="app-card" href="apps/simulador-esforcos.html">
+        <div class="app-icon" aria-hidden="true">⇆</div>
+        <h2>Simulador d'Esforços</h2>
+        <p>Visualitza com canvia una biga sota tracció o compressió segons la força aplicada.</p>
+      </a>
+      <a class="app-card" href="apps/calculadora-esforc-senzilla.html">
+        <div class="app-icon" aria-hidden="true">ΔL</div>
+        <h2>Calculadora d'Esforç Senzilla</h2>
+        <p>Recorregut pas a pas per calcular σ, ε i ΔL amb valors predefinits i fórmules visibles.</p>
+      </a>
+      <a class="app-card" href="apps/esforcos-mobil.html">
+        <div class="app-icon" aria-hidden="true">📱</div>
+        <h2>Esforços versió mòbil</h2>
+        <p>Calcula esforços i àrees en una interfície pensada específicament per a pantalles de mòbil.</p>
+      </a>
+    </section>
+  </main>
+  <footer>Fet per Juan Arambul com a complement al tema d'Estructures i Esforços</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add the Esforços versió mòbil app with a vertical mobile-first layout, sigma calculator, and rectangle/circle area helpers
- link the new mobile tool from the landing page grid so it is accessible with the rest of the collection
- tighten the sigma input layout so the force/area fields stay compact and the result stacks below on narrow screens

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e015b4b51883259bfb9a6780bbdd97